### PR TITLE
Update quotes in order.schema

### DIFF
--- a/order.schema
+++ b/order.schema
@@ -63,7 +63,6 @@
                     "nodeId",
                     "sequenceId",
                     "released",
-                    "allowedDeviation",
                     "actions"
                 ],
                 "properties": {

--- a/order.schema
+++ b/order.schema
@@ -295,7 +295,7 @@
                     "orientation": {
                         "type": "number",
                         "title": "orientation",
-                        "description": "Orientation of the AGV on the edge relative to the map coordinate origin (for holonomic vehicles with more than one driving direction).\nExample: orientation Pi/2 rad will lead to a rotation of 90 degrees.\nIf AGV starts in different orientation, rotate the vehicle on the edge to the desired orientation if rotationAllowed is set to “true”.\nIf rotationAllowed is “false", rotate before entering the edge.\nIf that is not possible, reject the order.\nIf a trajectory with orientation is defined, follow the trajectories orientation. If a trajectory without orientation and the orientation field here is defined, apply the orientation to the tangent of the trajectory.",
+                        "description": "Orientation of the AGV on the edge relative to the map coordinate origin (for holonomic vehicles with more than one driving direction).\nExample: orientation Pi/2 rad will lead to a rotation of 90 degrees.\nIf AGV starts in different orientation, rotate the vehicle on the edge to the desired orientation if rotationAllowed is set to “true”.\nIf rotationAllowed is “false”, rotate before entering the edge.\nIf that is not possible, reject the order.\nIf a trajectory with orientation is defined, follow the trajectories orientation. If a trajectory without orientation and the orientation field here is defined, apply the orientation to the tangent of the trajectory.",
                         "minimum": -3.14159265359,
                         "maximum": 3.14159265359
                     },


### PR DESCRIPTION
1. Change quotes in a `description` field, otherwise the syntax is broken and the parser thinks the string ends prematurely.
2. Remove `allowedDeviation` from the list of required attributes.

@MaximilianRies, can you have a look at this?