### PR TITLE
Updated node released summary refering to edge

### DIFF
--- a/order.schema
+++ b/order.schema
@@ -91,7 +91,7 @@
                     "released": {
                         "type": "boolean",
                         "title": "released",
-                        "description": "If true, the edge is part of the base plan. If false, the edge is part of the horizon plan."
+                        "description": "If true, the node is part of the base plan. If false, the node is part of the horizon plan."
                     },
                     "nodePosition": {
                         "title": "nodePosition",


### PR DESCRIPTION
This resolves: #13 where the summary for the released property now refers to the correct parent object
